### PR TITLE
Update dependencies to Soteria 1.0 and fix related imports

### DIFF
--- a/rest-basic-example/pom.xml
+++ b/rest-basic-example/pom.xml
@@ -18,11 +18,15 @@
             <version>7.0</version>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>javax.security.enterprise</groupId>
+            <artifactId>javax.security.enterprise-api</artifactId>
+            <version>1.0</version>
+        </dependency>
         <dependency>
             <groupId>org.glassfish.soteria</groupId>
-            <artifactId>soteria</artifactId>
-            <version>1.0-m02-SNAPSHOT</version>
+            <artifactId>javax.security.enterprise</artifactId>
+            <version>1.0</version>
         </dependency>
     </dependencies>
 

--- a/rest-basic-example/src/main/java/be/c4j/security/soteria/TestServlet.java
+++ b/rest-basic-example/src/main/java/be/c4j/security/soteria/TestServlet.java
@@ -42,9 +42,7 @@ package be.c4j.security.soteria;
 import java.io.IOException;
 
 import javax.annotation.security.DeclareRoles;
-import javax.security.authentication.mechanism.http.annotation.BasicAuthenticationMechanismDefinition;
-import javax.security.identitystore.annotation.Credentials;
-import javax.security.identitystore.annotation.EmbeddedIdentityStoreDefinition;
+import javax.security.enterprise.authentication.mechanism.http.BasicAuthenticationMechanismDefinition;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.HttpConstraint;
 import javax.servlet.annotation.ServletSecurity;
@@ -53,6 +51,9 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.glassfish.soteria.identitystores.annotation.Credentials;
+import org.glassfish.soteria.identitystores.annotation.EmbeddedIdentityStoreDefinition;
+
 /**
  * Servlet so that we have a chance to put the username/password in the Basic mechanism.
  */
@@ -60,7 +61,7 @@ import javax.servlet.http.HttpServletResponse;
     realmName="Soteria Realm"
 )
 
-@EmbeddedIdentityStoreDefinition({ 
+@EmbeddedIdentityStoreDefinition({
     @Credentials(callerName = "rudy", password = "secret1", groups = { "foo", "bar" }),
     @Credentials(callerName = "will", password = "secret2", groups = { "foo", "kaz" }),
     @Credentials(callerName = "arjan", password = "secret3", groups = { "foo" }) }


### PR DESCRIPTION
This is a fix to reference to issue #3.

There is one problem though.

When running the verify I needed to add a -Dskip.license=true as the license check fails due to a mix of 2016 and 2017 on the license headers.

I did not want to pollute this change with any potential license changes so I kept them out of this pull request. I am going to open a separate issue about the license verification.